### PR TITLE
NNG `argv` parameters + `npm install validator`

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -1,7 +1,10 @@
 import { Indexer } from './lib/indexer'
-import { NNG_PUB_URL, NNG_RPC_URL } from './util/constants'
 /**
  * RUNTIME
  */
-const indexer = new Indexer(NNG_PUB_URL, NNG_RPC_URL)
+const indexer = new Indexer(
+  String(process.argv[2]) as 'ipc' | 'tcp', // protocol
+  String(process.argv[3]), // pub.pipe
+  String(process.argv[4]), // rpc.pipe
+)
 indexer.init()

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,12 @@
         "@types/express": "^4.17.21",
         "@types/nanomsg": "^4.2.3",
         "@types/node": "^20.16.14",
+        "@types/validator": "^13.12.2",
         "express": "^4.21.1",
         "flatbuffers": "^24.3.25",
         "nanomsg": "file:local_modules/nanomsg",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "validator": "^13.12.0"
       },
       "devDependencies": {
         "prettier": "^3.3.3",
@@ -531,6 +533,11 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.12.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.12.2.tgz",
+      "integrity": "sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.10.0",
@@ -5402,6 +5409,14 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     "@types/express": "^4.17.21",
     "@types/nanomsg": "^4.2.3",
     "@types/node": "^20.16.14",
+    "@types/validator": "^13.12.2",
     "express": "^4.21.1",
     "flatbuffers": "^24.3.25",
     "nanomsg": "file:local_modules/nanomsg",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "validator": "^13.12.0"
   }
 }


### PR DESCRIPTION
`process.argv[2]`: protocol (`ipc | tcp`)
`process.argv[3]`: path to `pub.pipe`
`process.argv[4]`: path to `rpc.pipe`

Also added `validator` and `@types/validator` packages to validate the URIs for NNG `tcp` protocol. There were no dependencies for this package so there's no unnecessary bloat added. Also may be useful in the future for other checks or optimizing existing checks.